### PR TITLE
Run brakeman and dependency audits in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,22 @@ jobs:
           name: Run Brakeman scan
           command: bundle exec brakeman
 
+  dependency_audits:
+    docker:
+      - image: cimg/ruby:3.0.3-node
+    steps:
+      - checkout
+      - ruby/install-deps
+      - node/install-packages:
+          pkg-manager: yarn
+          cache-key: "yarn.lock"
+      - run:
+          name: Bundle audit
+          command: bundle exec rake bundler:audit
+      - run:
+          name: Yarn audit
+          command: bundle exec rake yarn:audit
+
 workflows:
   version: 2.1
   build_and_test:
@@ -83,5 +99,8 @@ workflows:
           requires:
             - build
       - brakeman:
+          requires:
+            - build
+      - dependency_audits:
           requires:
             - build


### PR DESCRIPTION
#1 

Changes:

* Addresses the postgres version comment in #2 
* Adds brakeman scan
* Adds bundler:audit & yarn:audit as a single job

Used one job for the dependency scans to try to balance having jobs responsible for one thing with cutting down on job start overhead. I could also see combining the audits with brakeman into one job as well.