### PR TITLE
Create foundry_0 terraform state bucket & infrastructure

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -37,7 +37,7 @@ The below steps rely on you first configuring access to the Terraform state in s
 
 1. Apply changes with `terraform apply`.
 
-  *TKTK, information about how the terraform gets applied by CI/CD, if we do that.*
+  *TKTK, information about how the terraform gets applied by CI/CD, when we do that.*
 
 1. Remove the space deployer service instance if it doesn't need to be used again, such as when manually running terraform once.
     ```bash

--- a/terraform/foundry_0/bootstrap/import.sh
+++ b/terraform/foundry_0/bootstrap/import.sh
@@ -4,8 +4,8 @@ read -p "Are you sure you want to import terraform state (y/n)? " verify
 
 if [[ $verify == "y" ]]; then
   echo "Importing bootstrap state"
-  ./run.sh import cloudfoundry_service_instance.shared_config_bucket TKTK-guid
-  ./run.sh import cloudfoundry_service_key.config_bucket_creds TKTK-guid
+  ./run.sh import module.s3.cloudfoundry_service_instance.bucket fa15ed09-9879-4e56-8421-db092a5bac8f
+  ./run.sh import module.s3.cloudfoundry_service_key.bucket_creds ee9363f8-47f2-4424-ba4e-ced6392177bf
   ./run.sh plan
 else
   echo "Not importing bootstrap state"

--- a/terraform/foundry_0/bootstrap/main.tf
+++ b/terraform/foundry_0/bootstrap/main.tf
@@ -7,7 +7,7 @@ module "s3" {
   cf_password     = var.cf_password
   cf_space_name   = "tah-prod"
   s3_service_name = "tah-shared-config"
-  s3_plan_name    = "basic"
+  s3_plan_name    = "basic-sandbox"
 }
 
 output "bucket_credentials" {

--- a/terraform/foundry_0/stage/main.tf
+++ b/terraform/foundry_0/stage/main.tf
@@ -1,12 +1,12 @@
 module "database" {
   source = "../../shared/database"
 
-  aws_region      = "us-gov-west-1"
-  cf_api_url      = "https://api.fr.cloud.gov"
+  aws_region       = "us-gov-west-1"
+  cf_api_url       = "https://api.fr.cloud.gov"
   cf_user          = var.cf_user
   cf_password      = var.cf_password
   cf_space_name    = "tah-stage"
   env              = "stage"
   recursive_delete = true
-  rds_plan_name    = "medium-gp-psql-redundant"
+  rds_plan_name    = "micro-psql"
 }

--- a/terraform/foundry_0/stage/providers.tf
+++ b/terraform/foundry_0/stage/providers.tf
@@ -11,7 +11,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket  = "TKTK"
+    bucket  = "cg-fa15ed09-9879-4e56-8421-db092a5bac8f"
     key     = "terraform.tfstate.stage"
     encrypt = "true"
     region  = "us-gov-west-1"


### PR DESCRIPTION
<details>
<summary>Create the state bucket:</summary>

```terraform
└─> ./run.sh apply
Running terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # module.s3.cloudfoundry_service_instance.bucket will be created
  + resource "cloudfoundry_service_instance" "bucket" {
      + id               = (known after apply)
      + name             = "tah-shared-config"
      + recursive_delete = false
      + service_plan     = "894d79e9-f406-45aa-b5e2-e5d407543d3f"
      + space            = "0e952e45-0dfb-43f8-96cb-c13b86950e35"
    }

  # module.s3.cloudfoundry_service_key.bucket_creds will be created
  + resource "cloudfoundry_service_key" "bucket_creds" {
      + credentials      = (known after apply)
      + id               = (known after apply)
      + name             = "tah-shared-config-access"
      + service_instance = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + bucket_credentials = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.s3.cloudfoundry_service_instance.bucket: Creating...
module.s3.cloudfoundry_service_instance.bucket: Creation complete after 6s [id=fa15ed09-9879-4e56-8421-db092a5bac8f]
module.s3.cloudfoundry_service_key.bucket_creds: Creating...
module.s3.cloudfoundry_service_key.bucket_creds: Creation complete after 1s [id=ee9363f8-47f2-4424-ba4e-ced6392177bf]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```
</details>

<details>
<summary>Create the RDS db:</summary>

```terraform
└─> terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.database.cloudfoundry_service_instance.rds will be created
  + resource "cloudfoundry_service_instance" "rds" {
      + id               = (known after apply)
      + name             = "test_at_home-rds-stage"
      + recursive_delete = true
      + service_plan     = "5ed9f319-4c75-4851-9885-598a96b7febc"
      + space            = "ff0cf17b-fb76-4773-916c-b2fbf064374e"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.database.cloudfoundry_service_instance.rds: Creating...
module.database.cloudfoundry_service_instance.rds: Still creating... [10s elapsed]
[snipped]
module.database.cloudfoundry_service_instance.rds: Still creating... [5m40s elapsed]
module.database.cloudfoundry_service_instance.rds: Creation complete after 5m43s [id=53cd398b-acd5-4555-8bb6-b8ab04699bf8]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
</details>

Switches to the infrastructure from earlier:

* Using `basic-sandbox` for s3 because `basic` isn't available in this foundry/org
* I switched to `micro-psql` since we won't be using foundry_0 for load testing anyway

The `space-deployer` used for each terraform run have both been removed.