### PR TITLE
Validate email format when provided (server-side)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "bootsnap", require: false
 gem "sassc-rails"
 
 gem "smartystreets_ruby_sdk", "~> 5.14"
+gem "valid_email", "~> 0.1"
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,9 @@ GEM
       sprockets-rails
       tilt
     secure_headers (6.3.3)
-    smartystreets_ruby_sdk (5.14.4)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
+    smartystreets_ruby_sdk (5.14.5)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -242,7 +244,14 @@ GEM
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
+    valid_email (0.1.4)
+      activemodel
+      mail (>= 2.6.1)
+      simpleidn
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -288,6 +297,7 @@ DEPENDENCIES
   sprockets-rails
   standard (~> 1.5)
   tzinfo-data
+  valid_email (~> 0.1)
   web-console
   webmock (~> 3.14)
 

--- a/app/models/kit_request.rb
+++ b/app/models/kit_request.rb
@@ -2,6 +2,7 @@ class KitRequest < ApplicationRecord
   encrypts :first_name, :last_name, :email, :mailing_address_1, :mailing_address_2, :smarty_response
 
   validates_presence_of :first_name, :last_name
+  validates :email, email: {message: I18n.t("activerecord.errors.messages.invalid_email")}, allow_blank: true
 
   validate :valid_mailing_address
   after_validation :store_smarty_response

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
         blank: can't be blank
         address_not_found: must be a valid USPS delivery address
         address_incorrect: seems to be incorrect. Please check for missing information
+        invalid_email: must be valid format
     attributes:
       first_name: First name
       last_name: Last name

--- a/spec/models/kit_request_spec.rb
+++ b/spec/models/kit_request_spec.rb
@@ -98,5 +98,18 @@ RSpec.describe KitRequest, type: :model do
         end
       end
     end
+
+    context "email" do
+      it "is not required" do
+        expect(FactoryBot.build(:kit_request, email: "")).to be_valid
+      end
+
+      context "when provided" do
+        it "validates format" do
+          expect(FactoryBot.build(:kit_request, email: "asdlfj")).to_not be_valid
+          expect(FactoryBot.build(:kit_request, email: "foo@example.com")).to be_valid
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Uses same library as Login IDP, but without MX lookup.

Server-side implementation for #42 