### PR TITLE
Require additional fields on backend when Smarty disabled

### DIFF
--- a/app/models/kit_request.rb
+++ b/app/models/kit_request.rb
@@ -4,7 +4,7 @@ class KitRequest < ApplicationRecord
   validates_presence_of :first_name, :last_name
   validates :email, email: {message: I18n.t("activerecord.errors.messages.invalid_email")}, allow_blank: true
 
-  validates_presence_of :email, if: -> { ENV["DISABLE_SMARTY_STREETS"] == "true" }
+  validates_presence_of :mailing_address_1, :city, :state, :zip_code, :email, if: -> { ENV["DISABLE_SMARTY_STREETS"] == "true" }
   validate :valid_mailing_address, unless: -> { ENV["DISABLE_SMARTY_STREETS"] == "true" }
 
   after_validation :store_smarty_response
@@ -16,7 +16,7 @@ class KitRequest < ApplicationRecord
   def valid_mailing_address
     begin
       validation_results = UsStreetAddressValidator.new(self).run
-    rescue UsStreetAddressValidator::ServiceIssueError => err
+    rescue UsStreetAddressValidator::ServiceIssueError
       return true
     end
 

--- a/spec/factories/kit_requests.rb
+++ b/spec/factories/kit_requests.rb
@@ -2,8 +2,13 @@ FactoryBot.define do
   factory :kit_request do
     first_name { "Test" }
     last_name { "McTester" }
-    mailing_address_1 { "1234 Fake Street" }
-    state { "OH" }
-    zip_code { "12345" }
+
+    trait :smarty_streets_disabled do
+      email { "foo@example.com" }
+      mailing_address_1 { "1234 Fake Street" }
+      city { "Lima" }
+      state { "OH" }
+      zip_code { "12345" }
+    end
   end
 end

--- a/spec/models/kit_request_spec.rb
+++ b/spec/models/kit_request_spec.rb
@@ -120,19 +120,22 @@ RSpec.describe KitRequest, type: :model do
       end
 
       it "does not require address validation" do
-        kit_request = FactoryBot.build(:kit_request, email: "foo@example.com")
+        kit_request = FactoryBot.build(:kit_request, :smarty_streets_disabled)
+
         expect(kit_request).to be_valid
         expect(kit_request.save).to be_truthy
       end
 
-      it "requires email to be present" do
-        kit_request = FactoryBot.build(:kit_request, email: "")
-
-        expect(kit_request).to_not be_valid
+      it "does require other address fields" do
+        expect(FactoryBot.build(:kit_request, :smarty_streets_disabled, email: "")).to_not be_valid
+        expect(FactoryBot.build(:kit_request, :smarty_streets_disabled, mailing_address_1: "")).to_not be_valid
+        expect(FactoryBot.build(:kit_request, :smarty_streets_disabled, city: "")).to_not be_valid
+        expect(FactoryBot.build(:kit_request, :smarty_streets_disabled, state: "")).to_not be_valid
+        expect(FactoryBot.build(:kit_request, :smarty_streets_disabled, zip_code: "")).to_not be_valid
       end
 
       it "requires email to be valid" do
-        kit_request = FactoryBot.build(:kit_request, email: "foo@elkjadf")
+        kit_request = FactoryBot.build(:kit_request, :smarty_streets_disabled, email: "foo@elkjadf")
 
         expect(kit_request).to_not be_valid
       end

--- a/spec/system/requesting_a_test_kit_spec.rb
+++ b/spec/system/requesting_a_test_kit_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe "Person requests a test kit", type: :system do
 
       fill_in "First name", with: "Kewpee"
       fill_in "Last name", with: "Doll"
-      fill_in "Email", with: "hello@example.com"
 
       fill_in "Mailing address 1", with: "1234 Fake St"
       fill_in "Mailing address 2", with: "Apt 2"
@@ -85,7 +84,6 @@ RSpec.describe "Person requests a test kit", type: :system do
       expect(page).to have_content("1234 Fake St")
       expect(page).to have_content("Apt 2")
       expect(page).to have_content("Lima, OH 12345")
-      expect(page).to have_content("fake@example.com")
 
       click_on "Edit"
 
@@ -99,6 +97,39 @@ RSpec.describe "Person requests a test kit", type: :system do
 
       expect(page).to have_content "Thank you, your pre-order has been placed."
     end
+
+    context "when smarty streets disabled" do
+      xit "requires email" do
+        ClimateControl.modify DISABLE_SMARTY_STREETS: "true" do
+          visit "/"
+
+          fill_in "First name", with: "Kewpee"
+          fill_in "Last name", with: "Doll"
+          fill_in "Email", with: "fake@example.com"
+
+          fill_in "Mailing address 1", with: "1234 Fake St"
+          fill_in "Mailing address 2", with: "Apt 2"
+          fill_in "City", with: "Lima"
+          find(:xpath, "//button[contains(@aria-label, 'Toggle the dropdown list')]").click
+          find("li", text: "OH - Ohio").click
+          fill_in "Zip code", with: "12345"
+
+          click_on "Review your order"
+
+          expect(page).to have_content("Email is required")
+
+          fill_in "Email", with: "real@example.com"
+
+          click_on "Review your order"
+
+          expect(page).to have_content("real@example.com")
+
+          click_on "Place your order"
+
+          expect(page).to have_content "Thank you, your pre-order has been placed."
+        end
+      end
+    end
   end
 
   describe "with javascript disabled" do
@@ -111,7 +142,6 @@ RSpec.describe "Person requests a test kit", type: :system do
 
       fill_in "First name", with: "Kewpee"
       fill_in "Last name", with: "Doll"
-      fill_in "Email", with: "hello@example.com"
 
       fill_in "Mailing address 1", with: "1234 Fake St"
       fill_in "Mailing address 2", with: "Apt 2"
@@ -122,6 +152,33 @@ RSpec.describe "Person requests a test kit", type: :system do
       click_on "Place your order"
 
       expect(page).to have_content "Thank you, your pre-order has been placed."
+    end
+
+    context "when smarty streets disabled" do
+      it "requires email" do
+        ClimateControl.modify DISABLE_SMARTY_STREETS: "true" do
+          visit "/"
+
+          fill_in "First name", with: "Kewpee"
+          fill_in "Last name", with: "Doll"
+
+          fill_in "Mailing address 1", with: "1234 Fake St"
+          fill_in "Mailing address 2", with: "Apt 2"
+          fill_in "City", with: "Lima"
+          select "OH", from: "State"
+          fill_in "Zip code", with: "12345"
+
+          click_on "Place your order"
+
+          expect(page).to have_content("email can't be blank")
+          fill_in "Email", with: "foo@example.com"
+          select "OH", from: "State" # Re-select for now
+
+          click_on "Place your order"
+
+          expect(page).to have_content "Thank you, your pre-order has been placed."
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Implements backend parts of #67. Also adds pending system test for when Javascript parts are in place.