### PR TITLE
Incorporate upstream landing page changes

### DIFF
--- a/app/assets/stylesheets/custom/_shared.scss
+++ b/app/assets/stylesheets/custom/_shared.scss
@@ -66,17 +66,20 @@ a.covidtest-button {
     display: inline-block;
     font-weight: 700;
     background: $color-cyan;
-    color: $color-dark-blue;
     border-radius: 90px;
     padding: units("205") units(4);
-    text-transform: uppercase;
-    text-decoration: none;
     text-align: center;
+
+    &,
+    &:visited {
+      color: #1b1b1b;
+      text-decoration: none;
+    }
 
     &:focus,
     &:hover {
-      color: $color-dark-blue;
-      text-decoration: underline;
+      color: #1b1b1b;
+      background: #28a0cb;
     }
   }
 }
@@ -97,20 +100,17 @@ a.covidtest-button {
 }
 
 .covidtest-logo {
-  margin-top: px-to-rem(10);
-  margin-bottom: px-to-rem(10);
+  @include at-media-max("tablet-lg") {
+    margin-top: px-to-rem(5);
+    margin-bottom: px-to-rem(5);
+  }
 
   @include at-media("mobile-lg") {
     @include covidtest-font(19);
   }
 
-  @include at-media("tablet") {
-    @include covidtest-font(24);
-  }
-
-  @include at-media("desktop") {
+  @include at-media("tablet-lg") {
     @include covidtest-font(37);
-    margin-top: 2px;
   }
 
   @include at-media("widescreen") {
@@ -133,6 +133,12 @@ a.covidtest-button {
     a {
       color: $color-blue;
       text-decoration: none;
+      border-left: 1px solid rgb(165, 173, 179);
+      padding-left: units(1);
+
+      @include at-media("desktop") {
+        padding-left: units(2);
+      }
     }
   }
 }
@@ -301,20 +307,17 @@ a.covidtest-button {
   }
 
   a {
-    position: relative;
-    color: $color-blue;
-    text-decoration: underline;
-    // text-decoration: none;
-    // background-image: linear-gradient(currentColor, currentColor);
-    // background-position: 0% 100%;
-    // background-repeat: no-repeat;
-    // background-size: 0% 1px;
-    transition: all 0.2s ease;
+    &,
+    &:visited {
+      position: relative;
+      color: $color-blue;
+      text-decoration: underline;
+      transition: all 0.2s ease;
+    }
 
     &:focus,
     &:hover {
       color: $color-magenta;
-      // background-size: 100% 1px;
     }
   }
 }
@@ -366,8 +369,8 @@ a.covidtest-button {
     }
     &-img {
       display: block;
-      max-width: 50px;
-      max-height: 50px;
+      max-width: 75px;
+      max-height: 75px;
 
       @include at-media("tablet") {
         max-width: 100px;
@@ -536,38 +539,13 @@ a.covidtest-button {
     }
 
     ul {
-      @include unstyled-list;
+      @include at-media("desktop") {
+        @include unstyled-list;
+      }
     }
 
     li {
-      a {
-        display: block;
-        @include covidtest-font(22, 30);
-        font-weight: 700;
-        text-decoration: none;
-        color: $color-dark-blue;
-
-        &::after {
-          content: "";
-          background: center / contain no-repeat
-            url("../img/covidtest/arrow.svg");
-          display: inline-block;
-          width: 29px;
-          height: 12px;
-          margin-left: units(1);
-          transition: transform 0.2s ease;
-        }
-
-        &:focus,
-        &:hover {
-          color: $color-blue;
-          text-decoration: underline;
-
-          &::after {
-            transform: translateX(units(1));
-          }
-        }
-      }
+      @include covidtest-font(22, 30);
 
       @include at-media("desktop") {
         margin-top: units(2px);
@@ -578,18 +556,43 @@ a.covidtest-button {
 
         a {
           display: flex;
-          justify-content: space-between;
           align-items: center;
           background-color: rgba($color-white, 0.94);
+          font-weight: 700;
           @include u-padding(2);
 
-          &::after {
+          &,
+          &:visited {
+            color: $color-dark-blue;
+            text-decoration: none;
+          }
+
+          &::before {
+            content: "";
+            order: 2;
+            flex-grow: 1;
+            background: center right / contain no-repeat
+              url("../img/covidtest/arrow.svg");
+            width: 29px;
+            height: 12px;
             margin-right: units(1);
+            margin-left: units(1);
+            transition: transform 0.2s ease;
+          }
+
+          &::after {
+            order: 1;
           }
 
           &:focus,
           &:hover {
+            color: $color-blue;
+            text-decoration: underline;
             background-color: $color-white;
+
+            &::before {
+              transform: translateX(units(1));
+            }
           }
         }
       }

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -10,9 +10,6 @@
       <a class="covidtest-footer__logo-link" href="https://wecandothis.hhs.gov/" rel="noopener">
         <img class="covidtest-footer__logo-img" src="images/covidtest/wecandothis-logo.svg" alt="<%= t('shared.footer.links.covid') %>" width="155" height="155" loading="lazy">
       </a>
-      <a class="covidtest-footer__logo-link covidtest-footer__logo-text" href="/">
-        <%= t('shared.header.title') %>
-      </a>
     </div>
   </div>
 </footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>COVIDtest.gov</title>
+    <title><%= t('shared.header.title') %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -28,9 +28,9 @@
         {
           "@context": "https://schema.org",
           "@type": "Organization",
-          "name":"COVIDtest.gov",
-          "url": "https://www.covidtest.gov/",
-          "logo": "https://www.covidtest.gov/favicon-196.png",
+          "name":"<%= t('shared.header.title') %>",
+          "url": "https://www.covidtests.gov/",
+          "logo": "https://www.covidtests.gov/favicon.ico",
           "parentOrganization": [
             {
               "@type": "Organization",
@@ -42,8 +42,8 @@
         {
           "@context": "https://schema.org",
           "@type": "WebSite",
-          "name": "COVIDtest.gov",
-          "url": "https://www.covidtest.gov/"
+          "name": "<%= t('shared.header.title') %>",
+          "url": "https://www.covidtests.gov/"
         }
       ]
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
       locked_padlock: A locked padlock
       us_flag: U.S. Flag
     header:
-      title: COVIDtest.gov
+      title: COVIDtests.gov
       menu: Menu
       primary: Primary navigation
       close: Close


### PR DESCRIPTION
Styles changes, along with renaming app to `COVIDtests.gov` (plural).