### PR TITLE
Associate address validation error with address fieldset

### DIFF
--- a/app/views/application/_card.html.erb
+++ b/app/views/application/_card.html.erb
@@ -1,7 +1,7 @@
 <div class="usa-card__container margin-x-0 margin-bottom-5 shadow-2">
   <div class="usa-card__body text-gray-90 padding-top-2 padding-bottom-4">
     <% if defined?(title) %>
-    <fieldset class="usa-fieldset">
+    <fieldset class="usa-fieldset" aria-describedby="<%= defined?(error_id) ? error_id : '' %>">
       <legend class="usa-legend text-blue margin-top-0 font-body-lg text-bold">
         <%= title %>
       </legend>

--- a/app/views/kit_requests/new.html.erb
+++ b/app/views/kit_requests/new.html.erb
@@ -39,7 +39,7 @@
           <%= form.text_field :last_name, class: "usa-input", required: true %>
         <% end %>
 
-        <%= render :layout => 'card', :locals => {:title => t('kit_requests.new.shipping_heading')} do %>
+        <%= render :layout => 'card', :locals => {:title => t('kit_requests.new.shipping_heading'), :error_id => 'address-err-cntr' } do %>
           <p class="font-body-xs">
             <%= t('kit_requests.new.shipping_html') %>
           </p>


### PR DESCRIPTION
Creates an association between the SmartyStreets address validation message and the shipping information fieldset to support better a11y.