### PR TITLE
Only export required i18n strings to frontend

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -15,9 +15,9 @@ const editButton = document.getElementById("edit-btn");
 const addressErrorContainer = document.getElementById("address-err-cntr");
 
 // i18n strings
-const reviewText = I18n.t("kit_requests.new.js.review");
-const submitText = I18n.t("kit_requests.new.js.submit");
-const emptyText = I18n.t("kit_requests.new.js.empty");
+const reviewText = I18n.t("js.review");
+const submitText = I18n.t("js.submit");
+const emptyText = I18n.t("js.empty");
 
 let isFormValid = false;
 

--- a/app/javascript/helpers/formValidation.js
+++ b/app/javascript/helpers/formValidation.js
@@ -1,7 +1,10 @@
 import i18n from "i18n-js";
 import Bouncer from "formbouncerjs";
 
-const invalidZipText = I18n.t("kit_requests.new.js.invalid.zip_code");
+const invalidZipText = I18n.t("js.invalid.zip_code");
+const missingSelect = I18n.t("js.invalid.missing_select");
+const missingDefault = I18n.t("js.invalid.missing_default");
+const invalidEmail = I18n.t("js.invalid.email");
 
 const validateForm = new Bouncer("#form", {
   disableSubmit: true,
@@ -14,7 +17,14 @@ const validateForm = new Bouncer("#form", {
     }
   },
   messages: {
-    isValidZip: invalidZipText
+    isValidZip: invalidZipText,
+    missingValue: {
+      select: missingSelect,
+      default: missingDefault
+    },
+    patternMismatch: {
+      email: invalidEmail
+    }
   }
 });
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,8 +62,8 @@
     </main>
     <%= render "application/footer" %>
     <%= javascript_tag nonce: true do %>
-      I18n.defaultLocale = "<%= I18n.default_locale %>"
-      I18n.locale = "<%= I18n.locale || I18n.default_locale %>"
+      I18n.defaultLocale = "<%= I18n.default_locale %>";
+      I18n.locale = "<%= I18n.locale || I18n.default_locale %>";
     <% end %>
   </body>
 </html>

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -1,0 +1,30 @@
+# Split context in several files.
+#
+# By default only one file with all translations is exported and
+# no configuration is required. Your settings for asset pipeline
+# are automatically recognized.
+#
+# If you want to split translations into several files or specify
+# locale contexts that will be exported, just use this file to do
+# so.
+#
+# For more informations about the export options with this file, please
+# refer to the README
+#
+#
+# If you're going to use the Rails 3.1 asset pipeline, change
+# the following configuration to something like this:
+#
+# translations:
+#   - file: "app/assets/javascripts/i18n/translations.js"
+#
+# If you're running an old version, you can use something
+# like this:
+#
+# translations:
+#   - file: "app/assets/javascripts/i18n/translations.js"
+#     only: "*"
+#
+translations:
+  - file: "public/javascripts/translations.js"
+    only: "*.js.*"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,11 +52,8 @@ en:
       us_flag: U.S. Flag
     header:
       title: COVIDtests.gov
-      menu: Menu
       primary: Primary navigation
-      close: Close
     footer:
-      return_top: Return to top
       links:
         hhs: U.S. Department of Health & Human Services
         usps: USPS.com
@@ -111,14 +108,17 @@ en:
           <p class="font-body-xs">You are not required to provide your name and address; however, not providing it will prevent USPS from shipping COVID tests to you. You are not required to provide your email address; however, not providing it will prevent USPS from emailing you shipment information.</p>
 
           <p class="font-body-xs">Any information you provide when placing your order will be shared with USPS and may also be disclosed as described in the published Privacy Act <a href="https://www.federalregister.gov/documents/2016/07/18/2016-16868/privacy-act-of-1974-notice-of-an-updated-system-of-records">System of Records Notice, usa.gov</a>.</p>
-      js:
-        review: Review your order
-        submit: Place your order
-        empty: Not provided
-        invalid:
-          address_not_found: Address must be a valid USPS delivery address
-          address_incorrect: Address seems to be incorrect. Please check for missing information
-          address_error: There was an error while validating your address
-          zip_code: Please provide a valid zip code
     confirmation:
       title: Thank you, your pre-order has been placed.
+  js:
+    review: Review your order
+    submit: Place your order
+    empty: Not provided
+    invalid:
+      address_not_found: Address must be a valid USPS delivery address
+      address_incorrect: Address seems to be incorrect. Please check for missing information
+      address_error: There was an error while validating your address
+      missing_select: Please select a value
+      missing_default: Please fill out this field
+      email: Please enter a valid email address
+      zip_code: Please provide a valid zip code


### PR DESCRIPTION
Previously, all i18n strings were being compiled for use on the frontend - we only need a handful of the strings available to the frontend, so this limits the output to only those.

Also added a number of additional strings that were previously not in i18n from the JS validation library.