### PR TITLE
Require email on frontend when smarty disabled

### DIFF
--- a/app/models/kit_request.rb
+++ b/app/models/kit_request.rb
@@ -4,8 +4,8 @@ class KitRequest < ApplicationRecord
   validates_presence_of :first_name, :last_name
   validates :email, email: {message: I18n.t("activerecord.errors.messages.invalid_email")}, allow_blank: true
 
-  validates_presence_of :mailing_address_1, :city, :state, :zip_code, :email, if: -> { ENV["DISABLE_SMARTY_STREETS"] == "true" }
-  validate :valid_mailing_address, unless: -> { ENV["DISABLE_SMARTY_STREETS"] == "true" }
+  validates_presence_of :mailing_address_1, :city, :state, :zip_code, :email, if: -> { UsStreetAddressValidator.smarty_disabled? }
+  validate :valid_mailing_address, unless: -> { UsStreetAddressValidator.smarty_disabled? }
 
   after_validation :store_smarty_response
 

--- a/app/services/us_street_address_validator.rb
+++ b/app/services/us_street_address_validator.rb
@@ -48,6 +48,10 @@ class UsStreetAddressValidator
     DELIVERABLE_MATCH_CODES.include?(candidate.analysis.dpv_match_code)
   end
 
+  def self.smarty_disabled?
+    ENV["DISABLE_SMARTY_STREETS"] == "true"
+  end
+
   private
 
   attr_reader :client, :lookup

--- a/app/views/kit_requests/new.html.erb
+++ b/app/views/kit_requests/new.html.erb
@@ -79,12 +79,18 @@
 
         <%= render :layout => 'card', :locals => {:title => t('kit_requests.new.tracking_heading') } do %>
           <p class="font-body-xs">
-            <%= t('kit_requests.new.tracking_html') %>
+            <%= t('kit_requests.new.tracking') %>
+            <% unless UsStreetAddressValidator.smarty_disabled? %>
+              <span class="text-italic text-blue"> <%= t('kit_requests.new.email_optional') %></span>
+            <% end %>
           </p>
           <%= form.label :email, class: "usa-label" do %>
-            <%= t('activerecord.attributes.email') %>
+            <%= t('activerecord.attributes.email') %> 
+            <% if UsStreetAddressValidator.smarty_disabled? %>
+              <span class="text-magenta">*</span>
+            <% end %>
           <% end %>
-          <%= form.email_field :email, class: "usa-input" %>
+          <%= form.email_field :email, class: "usa-input", required: UsStreetAddressValidator.smarty_disabled? ? true : false %>
         <% end %>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,8 +90,8 @@ en:
       shipping_html: >
         <span class="text-magenta">*</span><span class="text-italic">Required</span>
       tracking_heading: Order tracking
-      tracking_html: >
-        To receive updates on the status of your order from USPS, please provide an email address. <span class="text-italic text-blue">This step is optional, but we will not be able to provide tracking without an email.</span>
+      tracking: To receive updates on the status of your order from USPS, please provide an email address.
+      email_optional: This step is optional, but we will not be able to provide tracking without an email.
       error_header: "Couldn't process your request because of errors:"
       submit: Place your order
       review:

--- a/spec/services/us_street_address_validator_spec.rb
+++ b/spec/services/us_street_address_validator_spec.rb
@@ -31,4 +31,30 @@ RSpec.describe UsStreetAddressValidator, type: :model do
       end
     end
   end
+
+  describe ".smarty_disabled?" do
+    context "when env var not set" do
+      it "returns false" do
+        ClimateControl.modify DISABLE_SMARTY_STREETS: nil do
+          expect(UsStreetAddressValidator.smarty_disabled?).to eq(false)
+        end
+      end
+    end
+
+    context "when env var set to something that is not true" do
+      it "returns false" do
+        ClimateControl.modify DISABLE_SMARTY_STREETS: "alsdkj" do
+          expect(UsStreetAddressValidator.smarty_disabled?).to eq(false)
+        end
+      end
+    end
+
+    context "when env var set to true" do
+      it "returns true" do
+        ClimateControl.modify DISABLE_SMARTY_STREETS: "true" do
+          expect(UsStreetAddressValidator.smarty_disabled?).to eq(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/system/requesting_a_test_kit_spec.rb
+++ b/spec/system/requesting_a_test_kit_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe "Person requests a test kit", type: :system do
       find(:xpath, "//button[contains(@aria-label, 'Toggle the dropdown list')]").click
       find("li", text: "OH - Ohio").click
       fill_in "Zip code", with: "12345"
-      fill_in "Email", with: "fake@example.com"
 
       # Note: client-side address validations are currently silently failing in JS spec
       click_on "Review your order"
@@ -99,13 +98,12 @@ RSpec.describe "Person requests a test kit", type: :system do
     end
 
     context "when smarty streets disabled" do
-      xit "requires email" do
+      it "requires email" do
         ClimateControl.modify DISABLE_SMARTY_STREETS: "true" do
           visit "/"
 
           fill_in "First name", with: "Kewpee"
           fill_in "Last name", with: "Doll"
-          fill_in "Email", with: "fake@example.com"
 
           fill_in "Mailing address 1", with: "1234 Fake St"
           fill_in "Mailing address 2", with: "Apt 2"
@@ -116,7 +114,8 @@ RSpec.describe "Person requests a test kit", type: :system do
 
           click_on "Review your order"
 
-          expect(page).to have_content("Email is required")
+          expect(page).to_not have_content("This step is optional")
+          expect(page).to have_content("Please fill out this field")
 
           fill_in "Email", with: "real@example.com"
 
@@ -127,6 +126,8 @@ RSpec.describe "Person requests a test kit", type: :system do
           click_on "Place your order"
 
           expect(page).to have_content "Thank you, your pre-order has been placed."
+
+          assert_not_requested :any, /api.smartystreets.com/
         end
       end
     end
@@ -177,6 +178,8 @@ RSpec.describe "Person requests a test kit", type: :system do
           click_on "Place your order"
 
           expect(page).to have_content "Thank you, your pre-order has been placed."
+
+          assert_not_requested :any, /api.smartystreets.com/
         end
       end
     end


### PR DESCRIPTION
Also adds in spec around disabling smarty streets on front end

#67 