### PR TITLE
Log Smarty metrics to NewRelic

### DIFF
--- a/app/services/us_street_address_validator.rb
+++ b/app/services/us_street_address_validator.rb
@@ -34,9 +34,12 @@ class UsStreetAddressValidator
 
   def run
     begin
-      client.send_lookup(lookup)
+      results = client.send_lookup(lookup)
+      ::NewRelic::Agent.record_metric('Custom/Smarty/success', 1)
+      results
     # Possible exceptions: https://github.com/smartystreets/smartystreets-ruby-sdk/blob/master/lib/smartystreets_ruby_sdk/exceptions.rb
     rescue Net::OpenTimeout, SmartyStreets::SmartyError => err
+      ::NewRelic::Agent.record_metric('Custom/Smarty/success', 0)
       NewRelic::Agent.notice_error(err)
       raise ServiceIssueError
     end


### PR DESCRIPTION
NewRelic's support for external service metrics is limited to average response time and request volume out of the box. This PR adds a custom metric to track the success and failure of Smarty API calls. I don't know if there's something more specific in the API response that we'd like to track as well (status code, type of error, etc.), but this will give us the ability to create alerts for both success rate or total error volume.