### PR TITLE
Associate description with email input

### DIFF
--- a/app/views/kit_requests/new.html.erb
+++ b/app/views/kit_requests/new.html.erb
@@ -81,7 +81,7 @@
         <% end %>
 
         <%= render :layout => 'card', :locals => {:title => t('kit_requests.new.tracking_heading') } do %>
-          <p class="font-body-xs margin-top-0">
+          <p id="email-description" class="font-body-xs margin-top-0">
             <%= t('kit_requests.new.tracking') %>
             <% unless UsStreetAddressValidator.smarty_disabled? %>
               <span class="text-italic text-blue"> <%= t('kit_requests.new.email_optional') %></span>
@@ -93,7 +93,7 @@
               <span class="text-magenta">*</span>
             <% end %>
           <% end %>
-          <%= form.email_field :email, class: "usa-input", data: {'bouncer-email-length': true}, required: UsStreetAddressValidator.smarty_disabled? ? true : false, **error_options(@kit_request, :email) %>
+          <%= form.email_field :email, class: "usa-input", data: {'bouncer-email-length': true}, aria: {describedby: 'email-description'}, required: UsStreetAddressValidator.smarty_disabled? ? true : false, **error_options(@kit_request, :email) %>
           <%= accessible_errors(@kit_request, :email) %>
         <% end %>
       </div>


### PR DESCRIPTION
Fixes https://github.com/usagov/test-at-home/issues/151

To provide better context of when the email field is required/optional to folks using screenreaders, associate the fieldset description text with the input so that it is read automatically.