### PR TITLE
Address validation a11y fix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper
     opts[:hidden] = true if hidden
 
     if errored?(object, method) || hidden
-      content_tag("div", class: "error-message", id: accessible_error_id(object, method), **opts) do
+      content_tag("div", tabindex: -1, class: "error-message", id: accessible_error_id(object, method), **opts) do
         object.errors[method].map { |message| message }.join("<br/>")
       end
     end


### PR DESCRIPTION
Right now on the frontend if you are using a screenreader and enter an invalid address, the error message will be displayed but since it is not focused a non sighted user will not receive any feedback, just clicking submit w/ nothing happening. This change makes the div programmatically focusable, and sets focus to the error message on submit.