### PR TITLE
Fix Source Sans Font

### DIFF
--- a/app/assets/stylesheets/custom/_shared.scss
+++ b/app/assets/stylesheets/custom/_shared.scss
@@ -21,8 +21,9 @@ i.e.
 */
 $max-width: "desktop-lg";
 
-$font-family: "Source Sans Pro";
-$font-stack: #{$font-family}, sans;
+$font-family: "Source Sans Pro Web";
+$font-stack: #{$font-family}, Helvetica Neue, Helvetica, Roboto, Arial,
+  sans-serif;
 $font-size: 16;
 $line-height: 22;
 


### PR DESCRIPTION
Fixes font not rendering correctly:
<img width="1078" alt="Screen Shot 2022-01-17 at 2 03 21 PM" src="https://user-images.githubusercontent.com/1178494/149825145-9ff0c7f7-57d1-4e69-ad78-06b54ab6d2f7.png">
