### PR TITLE
Fix 500 page rendering

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,7 +4,7 @@ class ErrorsController < ApplicationController
   end
 
   def internal_server_error
-    render_confirmation
+    render_internal_server_error
   end
 
   private


### PR DESCRIPTION
Currently the `internal_server_error` route tries to `render_confirmation`, when I think we want to `render_internal_server_error`

(This also closes #248, but I noticed the page rendering issue while working it)