### PR TITLE
Track errored and successful submissions

### DIFF
--- a/app/controllers/kit_requests_controller.rb
+++ b/app/controllers/kit_requests_controller.rb
@@ -8,8 +8,10 @@ class KitRequestsController < ApplicationController
     @kit_request = KitRequest.new(kit_request_params)
 
     if @kit_request.save
+      ::NewRelic::Agent.increment_metric("Custom/Submission/success")
       render_confirmation
     else
+      ::NewRelic::Agent.increment_metric("Custom/Submission/error") 
       render :new
     end
   end


### PR DESCRIPTION
Notes about how to use here: https://docs.newrelic.com/docs/apm/agents/ruby-agent/api-guides/ruby-custom-metrics/

We are already sending something similar for Smarty and Recaptcha success and failures to give a monitor on service.

Ryan had raised concern of making sure New Relic is non-blocking for response in controller. I believe it is (starts async by default, and says that it's thread safe which suggests to me that it creates a new thread) but having trouble confirming through documentation or code. @mitchellhenke do you happen to know?

Closes #278 