### PR TITLE
Add test site banner and disable submission

### DIFF
--- a/app/assets/stylesheets/uswds/_uswds-theme-utilities.scss
+++ b/app/assets/stylesheets/uswds/_uswds-theme-utilities.scss
@@ -108,7 +108,7 @@ $align-self-settings: (
 );
 
 $background-color-settings: (
-  output: false,
+  output: true,
   responsive: false,
   active: false,
   focus: false,
@@ -198,7 +198,7 @@ $clearfix-settings: (
 );
 
 $color-settings: (
-  output: false,
+  output: true,
   responsive: false,
   active: false,
   focus: false,
@@ -607,7 +607,7 @@ $align-self-manual-values: ();
 
 // .background-color
 
-$background-color-palettes: ();
+$background-color-palettes: ("palette-color-system-red-vivid");
 $background-color-manual-values: ();
 
 // .border

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -175,6 +175,7 @@ const toggleContainer = () => {
     formContainer.removeAttribute("hidden", "");
     formContainer.querySelector("h1").focus();
     submitButton.value = reviewText;
+    submitButton.removeAttribute("disabled");
     privacyContainer.setAttribute("hidden", "");
   } else {
     formContainer.setAttribute("hidden", "");
@@ -184,6 +185,7 @@ const toggleContainer = () => {
     reviewContainer.removeAttribute("hidden", "");
     reviewContainer.querySelector("h1").focus();
     submitButton.value = submitText;
+    submitButton.setAttribute("disabled", true);
     privacyContainer.removeAttribute("hidden", "");
   } else {
     reviewContainer.setAttribute("hidden", "");
@@ -193,6 +195,7 @@ const toggleContainer = () => {
 if (form) {
   // Set up user interface
   submitButton.value = reviewText;
+  submitButton.removeAttribute("disabled");
   privacyContainer.setAttribute("hidden", "");
 
   // If DISABLE_SMARTY_STREETS_AUTOCOMPLETE=true, remove autocomplete

--- a/app/views/application/_usa_banner.html.erb
+++ b/app/views/application/_usa_banner.html.erb
@@ -1,51 +1,58 @@
 <a class="usa-skipnav" href="#main-content"><%= t('shared.skip_link') %></a>
+<header aria-label="banner">
+  <!-- Demo disclaimer -->
+  <div class="font-sans-lg padding-y-4 bg-red-70v text-white line-height-1 text-center">
+    TEST SITE - Do not use real personal information (demo purposes only) - TEST SITE
+  </div>
 
-<section class="usa-banner site-banner" aria-label="<%= t('shared.banner.official_site') %>">
-  <div class="usa-accordion">
-    <header class="usa-banner__header">
-      <div class="usa-banner__inner">
-        <div class="grid-col-auto">
-          <%= image_tag "uswds/dist/img/us_flag_small.png", alt: t('shared.banner.us_flag'), class: "usa-banner__header-flag" %>
-        </div>
-        <div class="grid-col-fill tablet:grid-col-auto">
-          <p class="usa-banner__header-text">
-            <%= t('shared.banner.official_site') %>
-          </p>
-          <p class="usa-banner__header-action" aria-hidden="true">
-            <%= t('shared.banner.how') %>
-          </p>
-        </div>
-        <button
-          class="usa-accordion__button usa-banner__button"
-          aria-expanded="false"
-          aria-controls="gov-banner"
-        >
-          <span class="usa-banner__button-text"><%= t('shared.banner.how') %></span>
-        </button>
-      </div>
-    </header>
-    <div class="usa-banner__content usa-accordion__content" id="gov-banner">
-      <%= javascript_tag nonce: true do %>
-        document.getElementById('gov-banner').setAttribute('hidden', '');
-      <% end %>
-      <div class="grid-row grid-gap-lg">
-        <div class="usa-banner__guidance tablet:grid-col-6">
-          <%= image_tag "uswds/dist/img/icon-dot-gov.svg", role: "img", "aria-hidden": true, class: "usa-banner__icon usa-media-block__img" %>
-          <div class="usa-media-block__body">
-            <strong><%= t('shared.banner.gov_heading') %></strong>
-            <br> <%= t('shared.banner.gov_description_html') %>
+  <!-- USA Banner -->
+  <section class="usa-banner site-banner" aria-label="<%= t('shared.banner.official_site') %>">
+    <div class="usa-accordion">
+      <header class="usa-banner__header">
+        <div class="usa-banner__inner">
+          <div class="grid-col-auto">
+            <%= image_tag "uswds/dist/img/us_flag_small.png", alt: t('shared.banner.us_flag'), class: "usa-banner__header-flag" %>
           </div>
-        </div>
-        <div class="usa-banner__guidance tablet:grid-col-6">
-          <%= image_tag "uswds/dist/img/icon-https.svg", role: "img", "aria-hidden": true, class: "usa-banner__icon usa-media-block__img" %>
-          <div class="usa-media-block__body">
-            <p>
-              <strong><%= t('shared.banner.secure_heading') %></strong>
-              <br> <%= t('shared.banner.secure_description_html', lock_icon: render('application/banner_lock_icon')) %>
+          <div class="grid-col-fill tablet:grid-col-auto">
+            <p class="usa-banner__header-text">
+              <%= t('shared.banner.official_site') %>
             </p>
+            <p class="usa-banner__header-action" aria-hidden="true">
+              <%= t('shared.banner.how') %>
+            </p>
+          </div>
+          <button
+            class="usa-accordion__button usa-banner__button"
+            aria-expanded="false"
+            aria-controls="gov-banner"
+          >
+            <span class="usa-banner__button-text"><%= t('shared.banner.how') %></span>
+          </button>
+        </div>
+      </header>
+      <div class="usa-banner__content usa-accordion__content" id="gov-banner">
+        <%= javascript_tag nonce: true do %>
+          document.getElementById('gov-banner').setAttribute('hidden', '');
+        <% end %>
+        <div class="grid-row grid-gap-lg">
+          <div class="usa-banner__guidance tablet:grid-col-6">
+            <%= image_tag "uswds/dist/img/icon-dot-gov.svg", role: "img", "aria-hidden": true, class: "usa-banner__icon usa-media-block__img" %>
+            <div class="usa-media-block__body">
+              <strong><%= t('shared.banner.gov_heading') %></strong>
+              <br> <%= t('shared.banner.gov_description_html') %>
+            </div>
+          </div>
+          <div class="usa-banner__guidance tablet:grid-col-6">
+            <%= image_tag "uswds/dist/img/icon-https.svg", role: "img", "aria-hidden": true, class: "usa-banner__icon usa-media-block__img" %>
+            <div class="usa-media-block__body">
+              <p>
+                <strong><%= t('shared.banner.secure_heading') %></strong>
+                <br> <%= t('shared.banner.secure_description_html', lock_icon: render('application/banner_lock_icon')) %>
+              </p>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+</header>

--- a/spec/system/requesting_a_test_kit_spec.rb
+++ b/spec/system/requesting_a_test_kit_spec.rb
@@ -99,9 +99,9 @@ RSpec.describe "Person requests a test kit", type: :system do
 
         expect(page).to have_content("real@example.com")
 
-        click_on "Place your order"
+        # click_on "Place your order"
 
-        expect(page).to have_content "Thank you, your order has been placed."
+        # expect(page).to have_content "Thank you, your order has been placed."
       end
     end
 
@@ -131,9 +131,9 @@ RSpec.describe "Person requests a test kit", type: :system do
 
           expect(page).to have_content("real@example.com")
 
-          click_on "Place your order"
+          # click_on "Place your order"
 
-          expect(page).to have_content "Thank you, your order has been placed."
+          # expect(page).to have_content "Thank you, your order has been placed."
 
           assert_not_requested :any, /api.smartystreets.com/
         end


### PR DESCRIPTION
To support autocomplete demo application.

* Text only in English, so put directly into HTML
* Demo banner and disabling always present, since I assume we're just a demo application at this point and wanted to get up quickly.
* Disables submission part of feature tests
* Adds in background color class from USWDS we need to match Login demo banner.

Note in case this impacts anyone else: I had to totally delete the compiled files in the `public` directory to get CSS and JS changes locally, even after turning off dev cache and running `yarn build` and `yarn build:css`.

Closes #315 